### PR TITLE
Add custom pageview property support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 .DS_Store
 node_modules
 /build
-/dist
 /.svelte-kit
-/package
 .env
 .env.*
 !.env.example

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,6 +4,5 @@
 	"trailingComma": "none",
 	"printWidth": 100,
 	"plugins": ["prettier-plugin-svelte"],
-	"pluginSearchDirs": ["."],
 	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
 }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm i --save-dev @accuser/svelte-plausible-analytics
 
 ## Examples
 
-Add Plausible Analytics to the root layout to track page views.
+### Add Plausible Analytics to the root layout to track page views.
 
 ```svelte
 <script>
@@ -25,7 +25,37 @@ Add Plausible Analytics to the root layout to track page views.
 <slot />
 ```
 
-Track analytics events:
+### Add custom properties to page views:
+
+```svelte
+<script>
+  import { page } from "$app/stores";
+  import { PlausibleAnalytics } from '@accuser/svelte-plausible-analytics';
+
+  $: ({ id: route } = $page?.route); // beware duplicate plausible calls
+</script>
+
+  <PlausibleAnalytics
+      enabled={true}
+      pageviewProps={{
+        route,
+        willNotBeIncluded: false,
+        message: `a template literal containing a ${dynamicValue}`,
+        testingFilter: "test-some-scenario",
+        "hyphenated-property": "filter value",
+      }}
+  />
+
+<slot />
+```
+
+Set custom properties in the `pageviewProps` Svelte prop on the `<PlausibleAnalytics />` component. *Beware hydration race conditions and take note when `<PlausibleAnalytics />` is mounted. Especially with SSG.*
+
+The Plausible-required `event-` prefix can be omitted. Eg. `<PlausibleAnalytics pageviewProps={{"my-fancy-prop": "a value"}} />` becomes `<script src="https://plausible.io/js/script.pageview-props.js" event-my-fancy-prop"="a value"></script>`.
+
+*Note*: as per the [Plausible documentation](https://plausible.io/docs/custom-props/introduction#limits), up to 30 custom properties can be included alongside a pageview by adding multiple attributes. There is also a 300/2000 character limit on each property `key` and `value`, respectively.
+
+### Track analytics events:
 
 ```svelte
 <script>
@@ -37,7 +67,7 @@ Track analytics events:
 <button on:click={login('Button')}>Click to login!</button>
 ```
 
-Track custom events:
+### Track custom events:
 
 ```svelte
 <script>

--- a/dist/PlausibleAnalytics.svelte
+++ b/dist/PlausibleAnalytics.svelte
@@ -1,0 +1,51 @@
+<script context="module">const plausible = (event, options) => window.plausible(event, options);
+</script>
+
+<script>import { onMount } from "svelte";
+import { dev } from "$app/environment";
+import { page } from "$app/stores";
+import { pa } from "./store";
+onMount(() => {
+  pa.subscribe((events) => {
+    let next = events.length && events.shift();
+    while (next) {
+      const { event, data } = next;
+      plausible(event, data);
+      next = events.shift();
+    }
+  });
+});
+export let apiHost = "https://plausible.io";
+export let compat = false;
+export let domain = $page.url.hostname;
+export let enabled = !dev;
+export let fileDownloads = false;
+export let hash = false;
+export let local = enabled && dev;
+export let outboundLinks = false;
+$:
+  api = `${apiHost}/api/event`;
+$:
+  src = [
+    `${apiHost}/js/script`,
+    compat ? "compat" : void 0,
+    fileDownloads ? "file-downloads" : void 0,
+    hash ? "hash" : void 0,
+    local ? "local" : void 0,
+    outboundLinks ? "outbound-links" : void 0,
+    "js"
+  ].filter(Boolean).join(".");
+</script>
+
+<svelte:head>
+	{#if enabled}
+		<script data-api={api} data-domain={domain.toString()} defer {src}></script>
+		<script>
+			window.plausible =
+				window.plausible ||
+				function () {
+					(window.plausible.q = window.plausible.q || []).push(arguments);
+				};
+		</script>
+	{/if}
+</svelte:head>

--- a/dist/PlausibleAnalytics.svelte.d.ts
+++ b/dist/PlausibleAnalytics.svelte.d.ts
@@ -1,0 +1,54 @@
+import { SvelteComponent } from "svelte";
+declare const __propDef: {
+    props: {
+        /**
+             * The API host.
+             *
+             * @defaultValue 'https://plausible.io'
+             */ apiHost?: string | undefined;
+        /**
+             * Compatibility mode for tracking users on Internet Explorer.
+             *
+             * @defaultValue false
+             */ compat?: boolean | undefined;
+        /**
+             * The domain name(s) of the website(s) to track.
+             *
+             * @defaultValue current hostname.
+             */ domain?: string | string[] | undefined;
+        /**
+             * Enable analytics.
+             *
+             * @defaultValue `true` in production mode, `false` in development mode.
+             */ enabled?: boolean | undefined;
+        /**
+             * Automatically track file downloads
+             * (Requires manual goal configuration on Plausible.)
+             * @defaultValue `false`
+             */ fileDownloads?: boolean | undefined;
+        /**
+             * Automatically follow frontend navigation when using hash-based routing.
+             *
+             * @defaultValue `false`
+             */ hash?: boolean | undefined;
+        /**
+             * Allow analytics to track on localhost (useful in hybrid apps).
+             * @defaultValue `false`, unless `enabled` is `true` in development mode.
+             */ local?: boolean | undefined;
+        /**
+             * Automatically track clicks on outbound links from your website.
+             * (Requires manual goal configuration on Plausible.)
+             * @defaultValue `false`
+             */ outboundLinks?: boolean | undefined;
+    };
+    events: {
+        [evt: string]: CustomEvent<any>;
+    };
+    slots: {};
+};
+export type PlausibleAnalyticsProps = typeof __propDef.props;
+export type PlausibleAnalyticsEvents = typeof __propDef.events;
+export type PlausibleAnalyticsSlots = typeof __propDef.slots;
+export default class PlausibleAnalytics extends SvelteComponent<PlausibleAnalyticsProps, PlausibleAnalyticsEvents, PlausibleAnalyticsSlots> {
+}
+export {};

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,2 @@
+export { default as PlausibleAnalytics } from './PlausibleAnalytics.svelte';
+export { pa } from './store';

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,2 @@
+export { default as PlausibleAnalytics } from './PlausibleAnalytics.svelte';
+export { pa } from './store';

--- a/dist/store.d.ts
+++ b/dist/store.d.ts
@@ -1,0 +1,67 @@
+/// <reference types="svelte" />
+interface PlausibleEvent {
+    event: string;
+    data?: unknown;
+}
+/**
+ * Plausible Analytics event store.
+ */
+export declare const pa: {
+    subscribe: (this: void, run: import("svelte/store").Subscriber<PlausibleEvent[]>, invalidate?: import("svelte/store").Invalidator<PlausibleEvent[]> | undefined) => import("svelte/store").Unsubscriber;
+    addEvent: (event: string, data?: unknown) => void;
+    /**
+     *
+     * @param method
+     * @returns
+     */
+    /**
+     * Send this event to signify that a user has logged in.
+     *
+     * @param method - The method used to login.
+     *
+     * @see {@link https://developers.google.com/analytics/devguides/collection/ga4/reference/events#parameters_14}
+     * @example
+     *
+     * pa.login('Google');
+     **/
+    login: (method?: string) => void;
+    /**
+     * Use this event to contextualize search operations. This event can help
+     * you identify the most popular content in your app.
+     *
+     * @param search_term - The term that was searched for.
+     *
+     * @see {@link https://developers.google.com/analytics/devguides/collection/ga4/reference/events#search}
+     * @example
+     *
+     * pa.search('t-shirts');
+     */
+    search: (search_term: string) => void;
+    /**
+     * Use this event when a user has shared content.
+     *
+     * @param method - The method in which the content is shared.
+     * @param content_type - The type of content shared.
+     * @param item_id - The ID of the shared content.
+     *
+     * @see {@link https://developers.google.com/analytics/devguides/collection/ga4/reference/events#share}
+     * @example
+     *
+     * pa.share('Twitter', 'image', 'C_12345');
+     */
+    share: (method?: string, content_type?: string, item_id?: string) => void;
+    /**
+     * This event indicates that a user has signed up for an account. Use this
+     * event to understand the different behaviors of logged in and logged out
+     * users.
+     *
+     * @param method - The method used for sign up.
+     *
+     * @see {@link https://developers.google.com/analytics/devguides/collection/ga4/reference/events#sign_up}
+     * @example
+     *
+     * pa.signup('Google');
+     */
+    signUp: (method?: string) => void;
+};
+export {};

--- a/dist/store.js
+++ b/dist/store.js
@@ -1,0 +1,68 @@
+import { writable } from 'svelte/store';
+/**
+ * Plausible Analytics event store.
+ */
+export const pa = (() => {
+    const { subscribe, update } = writable([]);
+    const addEvent = (event, data) => {
+        update((events) => [...events, { event, data }]);
+    };
+    return {
+        subscribe,
+        addEvent,
+        /**
+         *
+         * @param method
+         * @returns
+         */
+        /**
+         * Send this event to signify that a user has logged in.
+         *
+         * @param method - The method used to login.
+         *
+         * @see {@link https://developers.google.com/analytics/devguides/collection/ga4/reference/events#parameters_14}
+         * @example
+         *
+         * pa.login('Google');
+         **/
+        login: (method) => addEvent('login', { method }),
+        /**
+         * Use this event to contextualize search operations. This event can help
+         * you identify the most popular content in your app.
+         *
+         * @param search_term - The term that was searched for.
+         *
+         * @see {@link https://developers.google.com/analytics/devguides/collection/ga4/reference/events#search}
+         * @example
+         *
+         * pa.search('t-shirts');
+         */
+        search: (search_term) => addEvent('search', { search_term }),
+        /**
+         * Use this event when a user has shared content.
+         *
+         * @param method - The method in which the content is shared.
+         * @param content_type - The type of content shared.
+         * @param item_id - The ID of the shared content.
+         *
+         * @see {@link https://developers.google.com/analytics/devguides/collection/ga4/reference/events#share}
+         * @example
+         *
+         * pa.share('Twitter', 'image', 'C_12345');
+         */
+        share: (method, content_type, item_id) => addEvent('share', { method, content_type, item_id }),
+        /**
+         * This event indicates that a user has signed up for an account. Use this
+         * event to understand the different behaviors of logged in and logged out
+         * users.
+         *
+         * @param method - The method used for sign up.
+         *
+         * @see {@link https://developers.google.com/analytics/devguides/collection/ga4/reference/events#sign_up}
+         * @example
+         *
+         * pa.signup('Google');
+         */
+        signUp: (method) => addEvent('sign_up', { method })
+    };
+})();

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"svelte",
 		"sveltekit"
 	],
-	"homepage": "https://github.com/accuser/svelte-plausible-analytics/README.md",
+	"homepage": "https://github.com/accuser/svelte-plausible-analytics",
 	"bugs": {
 		"url": "https://github.com/accuser/svelte-plausible-analytics/issues"
 	},

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"test:unit": "vitest",
-		"lint": "prettier --plugin-search-dir . --check . && eslint .",
-		"format": "prettier --plugin-search-dir . --write ."
+		"lint": "prettier --check . && eslint .",
+		"format": "prettier --write ."
 	},
 	"exports": {
 		".": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,16 @@
 		"name": "Matthew Gibbons",
 		"url": "https://github.com/accuser"
 	},
+	"contributors": [
+		{
+			"name": "Jeffrey Palmer",
+			"url": "https://github.com/JeffreyPalmer"
+		},
+		{
+			"name": "Dan Grebb",
+			"url": "https://github.com/dgrebb"
+		}
+	],
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/accuser/svelte-plausible-analytics.git"

--- a/src/lib/PlausibleAnalytics.svelte
+++ b/src/lib/PlausibleAnalytics.svelte
@@ -7,6 +7,19 @@
 		plausible: PlausibleTracker;
 	}
 
+	/**
+	 * Type definition for properties that can be sent as part of a page view event to Plausible.
+	 * These properties can be of type boolean, number, or string.
+	 */
+	export type PageviewProp = boolean | number | string;
+
+	/**
+	 * Type definition for pageview properties.
+	 * Can be either a boolean or an array containing a record with keys of type number or string,
+	 * and values of type boolean, number, or string.
+	 */
+	export type PageviewProps = { [key: number | string]: PageviewProp } | boolean;
+
 	declare let window: PlausibleWindow;
 
 	const plausible: PlausibleTracker = (event, options) => window.plausible(event, options);
@@ -85,14 +98,67 @@
 	 */
 	export let outboundLinks = false;
 
+	/**
+	 * Holds the pageview properties to be used in the application.
+	 * The properties can be used for filtering in the Plausible dashboard. The pageview properties
+	 * are subject to certain limitations:
+	 * - Limited to 30 total custom properties per event.
+	 * - Limited to 300 characters per property name.
+	 * - Limited to 2000 characters per property value.
+	 *
+	 * @link https://plausible.io/docs/guided-tour#filtering for dashboard filtering by custom property details.
+	 * @defaultValue `false` Indicates no custom properties by default.
+	 */
+	export let pageviewProps: PageviewProps = false;
+
+	/**
+	 * Function references for property validation guards.
+	 * These are dynamically imported during development for validation purposes.
+	 */
+	let isCustomPropsLimit: Function, isCustomPropEntryLimit: Function;
+
+	/**
+	 * Sets the pageview properties as attributes on a given HTML script element.
+	 * This function is responsible for validating and applying the custom properties
+	 * defined in `pageviewProps` to the provided HTML element.
+	 *
+	 * @param {HTMLScriptElement} node - The HTML script element on which to set the attributes.
+	 */
+	const setPageviewProps: (node: HTMLScriptElement) => void = async (node) => {
+		// Early exit if pageviewProps is not defined or falsy.
+		if (!pageviewProps) return;
+
+		// In development mode, load validation guards dynamically and validate custom property limits.
+		if (dev) {
+			const guards = await import('./guards.js');
+			({ isCustomPropsLimit, isCustomPropEntryLimit } = guards);
+
+			// Validate the total number of custom properties against Plausible's limit.
+			isCustomPropsLimit(pageviewProps);
+		}
+
+		// Iterate over each key-value pair in pageviewProps to set them as attributes.
+		Object.entries(pageviewProps).forEach(([key, value]) => {
+			// In development mode, validate the length of property names and values.
+			if (dev) {
+				isCustomPropEntryLimit(300, key);
+				isCustomPropEntryLimit(2000, value);
+			}
+
+			// Set the attribute on the script node. Format: 'event-key'
+			node.setAttribute(`event-${key}`, String(value));
+		});
+	};
+
 	$: api = `${apiHost}/api/event`;
-	$: src = [
+	$: plausibleSrc = [
 		`${apiHost}/js/script`,
 		compat ? 'compat' : undefined,
 		fileDownloads ? 'file-downloads' : undefined,
 		hash ? 'hash' : undefined,
 		local ? 'local' : undefined,
 		outboundLinks ? 'outbound-links' : undefined,
+		pageviewProps ? 'pageview-props' : undefined,
 		'js'
 	]
 		.filter(Boolean)
@@ -101,7 +167,13 @@
 
 <svelte:head>
 	{#if enabled}
-		<script data-api={api} data-domain={domain.toString()} defer {src}></script>
+		<script
+			data-api={api}
+			data-domain={domain.toString()}
+			defer
+			src={plausibleSrc}
+			use:setPageviewProps
+		></script>
 		<script>
 			window.plausible =
 				window.plausible ||

--- a/src/lib/guards.ts
+++ b/src/lib/guards.ts
@@ -1,0 +1,96 @@
+import { type PageviewProp, type PageviewProps } from './PlausibleAnalytics.svelte';
+
+/**
+ * Handles various value types and issues warnings if the values are not suitable for passing to Plausible.
+ * Specifically checks for DOMTokenList, HTMLInputElement, Array, RegExp, and Date instances,
+ * and warns about potential errors if these are not parsed as strings.
+ *
+ * @param {unknown} value - The value to be handled and checked.
+ * @returns {boolean} Returns true if the value is acceptable, otherwise throws an error.
+ * @throws {Error} Throws an error if the value is neither a number nor a string.
+ */
+export const handleEntry = function handleEntry(entry: unknown): boolean {
+	const typeName = Object.prototype.toString.call(entry).slice(8, -1);
+
+	const warn = (type: string) =>
+		console.warn(
+			`Warning: Passing ${type} to Plausible may result in error unless parsed as a string.`
+		);
+
+	switch (typeName) {
+		case 'DOMTokenList':
+		case 'HTMLInputElement':
+		case 'Array':
+		case 'RegExp':
+		case 'Date':
+			warn(typeName);
+			return true;
+
+		case 'String':
+		case 'Number':
+			return true;
+
+		default:
+			console.warn(
+				`Plausible Error: Custom property entry ${entry} is not a boolean, number, or string.`
+			);
+			return true;
+	}
+};
+
+/**
+ * Checks if the number of custom properties in a PageviewProps object exceeds a specified limit.
+ *
+ * @param {PageviewProps} props - The PageviewProps object to check.
+ * @returns {boolean} Returns true if the number of properties is within the limit, otherwise logs a warning.
+ */
+export const isCustomPropsLimit = function isCustomPropsLimit(
+	props: PageviewProps
+): props is PageviewProps {
+	const limit = 30;
+
+	if (typeof props === 'object' && Object.entries(props).length > limit) {
+		console.warn(
+			`Warning: Plausible only allows up to 30 custom properties per event. ${props.length} properties counted.`
+		);
+	}
+
+	return true;
+};
+
+/**
+ * Checks if the length of a custom property name or value exceeds a specified limit.
+ *
+ * @param {number} limit - The maximum allowed character length.
+ * @param {PageviewProp} entry - The custom property entry to check.
+ * @returns {boolean} Returns true if the entry's length does not exceed the limit,  otherwise logs a warning.
+ */
+export const isCustomPropEntryLimit = function isCustomPropEntryLimit(
+	limit: number,
+	entry: PageviewProp
+): entry is PageviewProp {
+	const asString = entry.toString();
+	const warning = (length: number) =>
+		`Warning: Plausible limits custom property ${
+			limit > 300 ? 'values' : 'names'
+		} to ${limit} characters. ${entry} is ${length} characters.`;
+
+	// No checks needed for boolean
+	if (typeof entry === 'boolean') return true;
+
+	// Check character length of number with `toString()`
+	if (typeof entry === 'number' && asString.length > limit) {
+		console.warn(warning(asString.length));
+		return true;
+	}
+
+	// Check for and warn if interface passed as prop name or value
+	handleEntry(entry);
+
+	if (asString.length > limit) {
+		console.warn(warning(asString.length));
+		return false;
+	}
+
+	return true;
+};


### PR DESCRIPTION
I had the idea to implement [custom pageview properties](https://plausible.io/docs/custom-pageview-props#3-filter-your-dashboard-by-custom-properties) on a navigation/routing system for a personal project. This change adds:

1. Load the specific subset of Plausible `script` via `<PlausibleAnalytics />` prop
2. `setAttribute`s on the `<script>` tag via `pageviewprops={{"some-tracking-key": "some value"}}` and [Svelte's `use` action](https://css-tricks.com/using-custom-elements-in-svelte/#aa-using-a-svelte-action-to-force-setting-attributes).

Brief demo:

<details>
<summary><h3 style="display: inline;">Expand Animated Demo</summary>
![2023-07-09 21 31 00](https://github.com/accuser/svelte-plausible-analytics/assets/445891/5757a118-577c-4d60-9712-7363f6a4cc00)
</details>

Happy to discuss a better implementation! Cheers.