### PR TITLE
SvelteKit 2 migration and dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@accuser/svelte-plausible-analytics",
-	"version": "0.5.0",
+	"version": "1.0.0",
 	"description": "Plausible Analytics library for SvelteKit apps.",
 	"keywords": [
 		"analytics",
@@ -46,28 +46,29 @@
 		"!dist/**/*.spec.*"
 	],
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.20.4",
-		"svelte": "^4.0.0"
+		"@sveltejs/kit": "^1.30.3 || ^2.0.0",
+		"svelte": "^4.2.8"
 	},
 	"devDependencies": {
-		"@playwright/test": "^1.28.1",
-		"@sveltejs/adapter-auto": "^2.0.0",
-		"@sveltejs/kit": "^1.20.4",
-		"@sveltejs/package": "^2.0.0",
-		"@typescript-eslint/eslint-plugin": "^5.45.0",
-		"@typescript-eslint/parser": "^5.45.0",
-		"eslint": "^8.28.0",
-		"eslint-config-prettier": "^8.5.0",
-		"eslint-plugin-svelte": "^2.30.0",
-		"prettier": "^2.8.0",
-		"prettier-plugin-svelte": "^2.10.1",
-		"publint": "^0.1.9",
-		"svelte": "^4.0.0",
-		"svelte-check": "^3.4.3",
-		"tslib": "^2.4.1",
-		"typescript": "^5.0.0",
-		"vite": "^4.3.6",
-		"vitest": "^0.25.3"
+		"@playwright/test": "^1.40.1",
+		"@sveltejs/adapter-auto": "^3.0.0",
+		"@sveltejs/kit": "^2.0.0",
+		"@sveltejs/package": "^2.2.3",
+		"@typescript-eslint/eslint-plugin": "^6.14.0",
+		"@typescript-eslint/parser": "^6.14.0",
+		"eslint": "^8.56.0",
+		"eslint-config-prettier": "^9.1.0",
+		"eslint-plugin-svelte": "^2.35.1",
+		"prettier": "^3.1.1",
+		"prettier-plugin-svelte": "^3.1.2",
+		"publint": "^0.2.6",
+		"svelte": "^4.2.8",
+		"svelte-check": "^3.6.2",
+		"tslib": "^2.6.2",
+		"typescript": "^5.3.3",
+		"vite": "^5.0.10",
+		"vitest": "^1.0.4",
+		"@sveltejs/vite-plugin-svelte": "^3.0.1"
 	},
 	"svelte": "./dist/index.js",
 	"types": "./dist/index.d.ts",

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,5 +1,5 @@
 import adapter from '@sveltejs/adapter-auto';
-import { vitePreprocess } from '@sveltejs/kit/vite';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {


### PR DESCRIPTION
Adds backwards-compatible support for SvelteKit 2.

I included a version bump, but am happy to remove it.

Closes #12

- [x] tested with `@svelte/kit@1.27.6`
- [x] tested with `@svelte/kit@2.0.0`
- [x] tested with `vitePreprocess` from `@sveltejs/kit/vite`
- [x] tested with `vitePreprocess` from `@sveltejs/vite-plugin-svelte` (SvelteKit 2 change)
- [x] `npm test` passing